### PR TITLE
ballc format support

### DIFF
--- a/ALLCools/_allc_to_region_count.py
+++ b/ALLCools/_allc_to_region_count.py
@@ -135,6 +135,7 @@ def _map_to_sparse_chrom_bin(site_bed, out_bed, chrom_size_path, bin_size=500):
 )
 def allc_to_region_count(
     allc_path: str,
+    cmeta_path: str,
     output_prefix: str,
     chrom_size_path: str,
     mc_contexts: List[str],
@@ -215,6 +216,7 @@ def allc_to_region_count(
     strandness = "split" if split_strand else "both"
     output_paths_dict = extract_allc(
         allc_path=allc_path,
+        cmeta_path=cmeta_path,
         output_prefix=output_prefix,
         mc_contexts=mc_contexts,
         strandness=strandness,
@@ -332,10 +334,11 @@ def batch_allc_to_region_count(
 
     with ProcessPoolExecutor(cpu) as executor:
         futures = {}
-        for cell_id, allc_path in allc_series.iteritems():
+        for cell_id, (allc_path, cmeta_path) in allc_series.iterrows():
             future = executor.submit(
                 allc_to_region_count,
                 allc_path=allc_path,
+                cmeta_path=cmeta_path,
                 output_prefix=str(output_dir / cell_id),
                 chrom_size_path=chrom_size_path,
                 mc_contexts=mc_contexts,

--- a/ALLCools/_extract_allc.py
+++ b/ALLCools/_extract_allc.py
@@ -219,6 +219,7 @@ def _extract_allc_parallel(
 )
 def extract_allc(
     allc_path: str,
+    cmeta_path: str,
     output_prefix: str,
     mc_contexts: Union[str, list],
     chrom_size_path: str,
@@ -346,7 +347,7 @@ def extract_allc(
 
     # split file first
     # strandness function
-    with open_allc(allc_path, region=region) as allc:
+    with open_allc(allc_path, region=region, cmeta_path=cmeta_path) as allc:
         if strandness == "Split":
             for line in allc:
                 cur_line = line.split("\t")

--- a/ALLCools/_open.py
+++ b/ALLCools/_open.py
@@ -154,7 +154,7 @@ class PipedGzipWriter(Closing):
         self.outfile.close()
         self.devnull.close()
         if return_code != 0:
-            raise IOError(f"Output {self.program} process terminated with exit code {return_code}")
+            raise OSError(f"Output {self.program} process terminated with exit code {return_code}")
 
 
 class PipedGzipReader(Closing):
@@ -223,10 +223,9 @@ class PipedGzipReader(Closing):
         return data
 
 
-
 class PipedBAllCReader(Closing):
     def __init__(self, path, cmeta_path=None, region=None, mode="r"):
-        if mode not in ('r'):
+        if mode not in ("r"):
             raise ValueError(f"Mode can only be 'r' for ballc file")
         if cmeta_path is None:
             raise NotImplementedError
@@ -235,17 +234,22 @@ class PipedBAllCReader(Closing):
             raise FileNotFoundError(f"{cmeta_path} does not exist.")
         cmeta_path = str(cmeta_path)
 
-
         if region is None:
-            self.process = Popen(["ballcools", "query", path, "\"*\"", "-c", cmeta_path],
-                                 #stdout=PIPE, stderr=PIPE, encoding="utf8")
-                                 stdout=PIPE, stderr=PIPE, encoding=None)
+            self.process = Popen(
+                ["ballcools", "query", path, '"*"', "-c", cmeta_path],
+                # stdout=PIPE, stderr=PIPE, encoding="utf8")
+                stdout=PIPE,
+                stderr=PIPE,
+                encoding=None,
+            )
         else:
-            self.process = Popen(["ballcools", "query", path]+ region.split(" ")+["-c",cmeta_path],
-                                 stdout=PIPE,
-                                 stderr=PIPE,
-                                 #encoding="utf8",)
-                                 encoding=None,)
+            self.process = Popen(
+                ["ballcools", "query", path] + region.split(" ") + ["-c", cmeta_path],
+                stdout=PIPE,
+                stderr=PIPE,
+                # encoding="utf8",)
+                encoding=None,
+            )
 
         self.name = path
         self._file = self.process.stdout
@@ -266,12 +270,12 @@ class PipedBAllCReader(Closing):
 
     def __iter__(self):
         for line in self._file:
-            yield line.decode('utf-8')
+            yield line.decode("utf-8")
         self.process.wait()
         self._raise_if_error()
 
     def readline(self):
-        return self._file.readline().decode('utf-8')
+        return self._file.readline().decode("utf-8")
 
     def _raise_if_error(self):
         """
@@ -450,8 +454,10 @@ def open_gz(file_path, mode="r", compresslevel=3, threads=1, region=None):
         except OSError:
             return gzip.open(file_path, mode, compresslevel=compresslevel)
 
+
 def open_ballc(file_path, mode="r", compresslevel=None, threads=None, region=None, cmeta_path=None):
     return PipedBAllCReader(file_path, cmeta_path=cmeta_path, region=region, mode="r")
+
 
 def open_allc(file_path, mode="r", compresslevel=3, threads=1, region=None, cmeta_path=None):
     """
@@ -508,7 +514,7 @@ def open_allc(file_path, mode="r", compresslevel=3, threads=1, region=None, cmet
 
     if file_path.endswith(".gz"):
         return open_gz(file_path, mode, compresslevel, threads, region=region)
-    elif file_path.endswith(".ballc"): 
+    elif file_path.endswith(".ballc"):
         return open_ballc(file_path, region=region, cmeta_path=cmeta_path)
     else:
         return open(file_path, mode)

--- a/ALLCools/_open.py
+++ b/ALLCools/_open.py
@@ -154,7 +154,7 @@ class PipedGzipWriter(Closing):
         self.outfile.close()
         self.devnull.close()
         if return_code != 0:
-            raise OSError(f"Output {self.program} process terminated with exit code {return_code}")
+            raise IOError(f"Output {self.program} process terminated with exit code {return_code}")
 
 
 class PipedGzipReader(Closing):
@@ -206,7 +206,76 @@ class PipedGzipReader(Closing):
         """
         Raise an exception if the gzip process has exited with an error.
 
-        Raise IOError if process is not running anymore and the
+        Raise OSError if process is not running anymore and the
+        exit code is nonzero.
+        """
+        return_code = self.process.poll()
+        if return_code is not None and return_code != 0:
+            message = self._stderr.read().strip()
+            raise OSError(message)
+
+    def read(self, *args):
+        data = self._file.read(*args)
+        if len(args) == 0 or args[0] <= 0:
+            # wait for process to terminate until we check the exit code
+            self.process.wait()
+        self._raise_if_error()
+        return data
+
+
+
+class PipedBAllCReader(Closing):
+    def __init__(self, path, cmeta_path=None, region=None, mode="r"):
+        if mode not in ('r'):
+            raise ValueError(f"Mode can only be 'r' for ballc file")
+        if cmeta_path is None:
+            raise NotImplementedError
+        cmeta_path = pathlib.Path(cmeta_path).resolve()
+        if not cmeta_path.exists():
+            raise FileNotFoundError(f"{cmeta_path} does not exist.")
+        cmeta_path = str(cmeta_path)
+
+
+        if region is None:
+            self.process = Popen(["ballcools", "query", path, "\"*\"", "-c", cmeta_path],
+                                 #stdout=PIPE, stderr=PIPE, encoding="utf8")
+                                 stdout=PIPE, stderr=PIPE, encoding=None)
+        else:
+            self.process = Popen(["ballcools", "query", path]+ region.split(" ")+["-c",cmeta_path],
+                                 stdout=PIPE,
+                                 stderr=PIPE,
+                                 #encoding="utf8",)
+                                 encoding=None,)
+
+        self.name = path
+        self._file = self.process.stdout
+        self._stderr = self.process.stderr
+        self.closed = False
+        # Give ballcools a little bit of time to report any errors
+        # (such as a non-existing file)
+        time.sleep(0.01)
+        self._raise_if_error()
+
+    def close(self):
+        self.closed = True
+        return_code = self.process.poll()
+        if return_code is None:
+            # still running
+            self.process.terminate()
+        self._raise_if_error()
+
+    def __iter__(self):
+        for line in self._file:
+            yield line.decode('utf-8')
+        self.process.wait()
+        self._raise_if_error()
+
+    def readline(self):
+        return self._file.readline().decode('utf-8')
+
+    def _raise_if_error(self):
+        """
+        Raise OSError if process is not running anymore and the
         exit code is nonzero.
         """
         return_code = self.process.poll()
@@ -275,7 +344,7 @@ class PipedBamReader(Closing):
         return self.file.readline()
 
     def _raise_if_error(self):
-        """Raise IOError if process is not running anymore and the exit code is nonzero."""
+        """Raise OSError if process is not running anymore and the exit code is nonzero."""
         return_code = self.process.poll()
         if return_code is not None and return_code != 0:
             message = self._stderr.read().strip()
@@ -381,8 +450,10 @@ def open_gz(file_path, mode="r", compresslevel=3, threads=1, region=None):
         except OSError:
             return gzip.open(file_path, mode, compresslevel=compresslevel)
 
+def open_ballc(file_path, mode="r", compresslevel=None, threads=None, region=None, cmeta_path=None):
+    return PipedBAllCReader(file_path, cmeta_path=cmeta_path, region=region, mode="r")
 
-def open_allc(file_path, mode="r", compresslevel=3, threads=1, region=None):
+def open_allc(file_path, mode="r", compresslevel=3, threads=1, region=None, cmeta_path=None):
     """
     Open a .allc file.
 
@@ -422,7 +493,7 @@ def open_allc(file_path, mode="r", compresslevel=3, threads=1, region=None):
         raise ValueError(f"mode '{mode}' not supported")
     if compresslevel not in range(1, 10):
         raise ValueError("compresslevel must be between 1 and 9")
-    if region is not None:
+    if (region is not None) and (not file_path.endswith(".ballc")):
         # unzipped file
         if not file_path.endswith("gz"):
             raise ValueError(f"File must be compressed by bgzip to use region query. File path {file_path}")
@@ -435,8 +506,10 @@ def open_allc(file_path, mode="r", compresslevel=3, threads=1, region=None):
         if not os.path.exists(file_path + ".tbi"):
             raise FileNotFoundError("region query provided, but .tbi index not found")
 
-    if file_path.endswith("gz"):
+    if file_path.endswith(".gz"):
         return open_gz(file_path, mode, compresslevel, threads, region=region)
+    elif file_path.endswith(".ballc"): 
+        return open_ballc(file_path, region=region, cmeta_path=cmeta_path)
     else:
         return open(file_path, mode)
 

--- a/ALLCools/count_matrix/mcds.py
+++ b/ALLCools/count_matrix/mcds.py
@@ -332,12 +332,14 @@ def generate_mcds(
 
     if isinstance(allc_table, str):
         allc_series = pd.read_csv(allc_table, header=None, index_col=0, sep="\t")
-        if allc_series.shape[1]==1:
-            allc_series[2]=''
-        elif allc_series.shape[1]==2:
+        if allc_series.shape[1] == 1:
+            allc_series[2] = ""
+        elif allc_series.shape[1] == 2:
             pass
         else:
-            raise ValueError("allc_table malformed, should have 2 or 3 columns, 1. file_uid, 2. file_path, 3. cmeta_path if ballc format")
+            raise ValueError(
+                "allc_table malformed, should have 2 or 3 columns, 1. file_uid, 2. file_path, 3. cmeta_path if ballc format"
+            )
     else:
         allc_series = allc_table[~allc_table[1].isna()]
     if allc_series.index.duplicated().sum() != 0:


### PR DESCRIPTION
### Major:

generation of MCDS from BAllC format is supported now.

to generate mcds from ballc, now users can use same command line as the files were of the allc format. the only difference is that users need to provide the corresponding cmeta file (see [ballcools](https://github.com/jksr/ballcools/blob/main/doc/ballc_spec.pdf) for reference) in an additional column in the allc_table (`--allc_table`) to use ballc files.

Nothing needs to change to keep using allc format.


### Minor:
deprecated pandas functions now are changed to the working ones.
