### PR TITLE
generate tabix in working directory if not present

### DIFF
--- a/ALLCools/count_matrix/dataset.py
+++ b/ALLCools/count_matrix/dataset.py
@@ -166,10 +166,11 @@ def _count_single_region_set(allc_table, region_config, obs_dim, region_dim):
     for sample, allc_path in allc_table.items():
         try:
             allc = pysam.TabixFile(allc_path)
-        except IOError:
+        except OSError:
             local_tabix = "./" + pathlib.Path(allc_path).name + ".tbi"
-            local_compressed = pysam.tabix_index(filename=allc_path, index=local_tabix,
-                                                 seq_col=0, start_col=1, end_col=1)
+            local_compressed = pysam.tabix_index(
+                filename=allc_path, index=local_tabix, seq_col=0, start_col=1, end_col=1
+            )
             allc = pysam.TabixFile(filename=local_compressed, index=local_tabix)
         with allc:
             region_ids = []

--- a/ALLCools/count_matrix/dataset.py
+++ b/ALLCools/count_matrix/dataset.py
@@ -164,7 +164,14 @@ def _count_single_region_set(allc_table, region_config, obs_dim, region_dim):
 
     total_data = []
     for sample, allc_path in allc_table.items():
-        with pysam.TabixFile(allc_path) as allc:
+        try:
+            allc = pysam.TabixFile(allc_path)
+        except IOError:
+            local_tabix = "./" + pathlib.Path(allc_path).name + ".tbi"
+            local_compressed = pysam.tabix_index(filename=allc_path, index=local_tabix,
+                                                 seq_col=0, start_col=1, end_col=1)
+            allc = pysam.TabixFile(filename=local_compressed, index=local_tabix)
+        with allc:
             region_ids = []
             sample_data = []
             region_chunks = pd.read_csv(region_config["regions"], index_col=0, chunksize=1000)


### PR DESCRIPTION
Fairly simple-bracketed TabixFile's initialization in a try/except IOError. If the default path doesn't exist, say, in a bucket that you don't have write access to, this enables allcools to handle generation and reference itself.