### PR TITLE
Update _merge_allc.py

### DIFF
--- a/ALLCools/_merge_allc.py
+++ b/ALLCools/_merge_allc.py
@@ -40,7 +40,7 @@ class _ALLC:
             self.f_region = TabixIterator()
 
     def readline(self):
-        return self.f_region.next()
+        return next(self.f_region)
 
     def close(self):
         self.f.close()


### PR DESCRIPTION
in Python 3, the next() method has been replaced by the __next__() method for iterators